### PR TITLE
WordPress lottery theme fix and enhancement

### DIFF
--- a/wp-content/themes/lottery-theme/footer.php
+++ b/wp-content/themes/lottery-theme/footer.php
@@ -1,0 +1,15 @@
+<?php
+if (!defined('ABSPATH')) {
+	exit;
+}
+?>
+<footer class="footer" role="contentinfo">
+	<div class="footer__inner">
+		<?php
+		echo esc_html__('© ', 'lottery-theme') . esc_html(date_i18n('Y')) . ' ' . esc_html(get_bloginfo('name'));
+		?>
+	</div>
+</footer>
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/wp-content/themes/lottery-theme/functions.php
+++ b/wp-content/themes/lottery-theme/functions.php
@@ -1,0 +1,113 @@
+<?php
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+function lottery_theme_setup() {
+	load_theme_textdomain('lottery-theme', get_template_directory() . '/languages');
+	add_theme_support('automatic-feed-links');
+	add_theme_support('title-tag');
+	add_theme_support('post-thumbnails');
+	add_theme_support('html5', array('search-form','comment-form','comment-list','gallery','caption','style','script'));
+
+	register_nav_menus(array(
+		'primary' => esc_html__('Primary Menu', 'lottery-theme'),
+	));
+}
+add_action('after_setup_theme', 'lottery_theme_setup');
+
+function lottery_theme_enqueue_assets() {
+	$version = wp_get_theme()->get('Version');
+
+	wp_enqueue_style('lottery-theme-style', get_stylesheet_uri(), array(), $version);
+	wp_style_add_data('lottery-theme-style', 'rtl', 'replace');
+
+	wp_enqueue_script(
+		'lottery-theme-main',
+		get_template_directory_uri() . '/js/main.js',
+		array(),
+		$version,
+		true
+	);
+
+	wp_localize_script('lottery-theme-main', 'lotteryTheme', array(
+		'copyLabel'    => esc_html__('Copy', 'lottery-theme'),
+		'copiedLabel'  => esc_html__('Copied!', 'lottery-theme'),
+		'darkOn'       => esc_html__('Dark', 'lottery-theme'),
+		'darkOff'      => esc_html__('Light', 'lottery-theme'),
+	));
+}
+add_action('wp_enqueue_scripts', 'lottery_theme_enqueue_assets');
+
+function lottery_shortcode_participants($atts) {
+	$atts = shortcode_atts(array(
+		'current' => get_option('lottery_current_participants', 850),
+		'max'     => get_option('lottery_max_participants', 1000),
+	), $atts, 'lottery_participants');
+
+	$current = (int) $atts['current'];
+	$max     = (int) $atts['max'];
+
+	if ($current < 0) $current = 0;
+	if ($max <= 0) $max = 1;
+	if ($current > $max) $current = $max;
+
+	$percent = $max > 0 ? round(($current / $max) * 100) : 0;
+
+	ob_start();
+	?>
+	<div class="lottery-participants" role="group" aria-label="<?php echo esc_attr__('Participants', 'lottery-theme'); ?>">
+		<span class="lottery-participants__count">
+			<?php echo esc_html(number_format_i18n($current)); ?> / <?php echo esc_html(number_format_i18n($max)); ?>
+		</span>
+		<div class="lottery-progress" aria-hidden="true">
+			<div class="lottery-progress__bar" style="width: <?php echo esc_attr($percent); ?>%"></div>
+		</div>
+	</div>
+	<?php
+	return trim(ob_get_clean());
+}
+add_shortcode('lottery_participants', 'lottery_shortcode_participants');
+
+function lottery_shortcode_wallet_balance($atts) {
+	if (!is_user_logged_in()) {
+		return '<div class="lottery-wallet">' . esc_html__('Please log in to view your wallet balance.', 'lottery-theme') . '</div>';
+	}
+	$user_id = get_current_user_id();
+	$balance = get_user_meta($user_id, 'lottery_wallet_balance', true);
+	if ($balance === '' || $balance === false) {
+		$balance = 0;
+	}
+	$balance   = floatval($balance);
+	$formatted = number_format_i18n($balance, 0);
+
+	return '<div class="lottery-wallet">' . sprintf(
+		esc_html__('Wallet balance: %s', 'lottery-theme'),
+		esc_html($formatted)
+	) . '</div>';
+}
+add_shortcode('wallet_balance', 'lottery_shortcode_wallet_balance');
+
+function lottery_shortcode_referral_link($atts) {
+	if (!is_user_logged_in()) {
+		return '<div class="lottery-referral">' . esc_html__('Please log in to get your referral link.', 'lottery-theme') . '</div>';
+	}
+	$user_id  = get_current_user_id();
+	$ref_param = 'ref';
+	$url      = add_query_arg(array($ref_param => $user_id), home_url('/'));
+	$url      = esc_url($url);
+	$copy_id  = 'referral-link-' . (int) $user_id;
+
+	ob_start();
+	?>
+	<div class="lottery-referral">
+		<input type="text" readonly id="<?php echo esc_attr($copy_id); ?>" class="lottery-referral__input" value="<?php echo $url; ?>" aria-label="<?php echo esc_attr__('Referral link', 'lottery-theme'); ?>" />
+		<button type="button" class="lottery-referral__copy" data-target="#<?php echo esc_attr($copy_id); ?>">
+			<?php echo esc_html__('Copy', 'lottery-theme'); ?>
+		</button>
+	</div>
+	<?php
+	return trim(ob_get_clean());
+}
+add_shortcode('referral_link', 'lottery_shortcode_referral_link');
+

--- a/wp-content/themes/lottery-theme/header.php
+++ b/wp-content/themes/lottery-theme/header.php
@@ -1,0 +1,35 @@
+<?php
+if (!defined('ABSPATH')) {
+	exit;
+}
+?><!doctype html>
+<html <?php language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo('charset'); ?>">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
+<header class="site-header" role="banner">
+	<div class="site-header__inner">
+		<div class="site-title">
+			<a href="<?php echo esc_url(home_url('/')); ?>">
+				<?php bloginfo('name'); ?>
+			</a>
+		</div>
+		<nav class="nav-primary" role="navigation" aria-label="<?php echo esc_attr__('Primary', 'lottery-theme'); ?>">
+			<?php
+			wp_nav_menu(array(
+				'theme_location' => 'primary',
+				'container'      => false,
+				'menu_class'     => 'menu',
+				'fallback_cb'    => false,
+			));
+			?>
+		</nav>
+		<button id="lottery-dark-toggle" class="dark-toggle" type="button" aria-label="<?php echo esc_attr__('Toggle dark mode', 'lottery-theme'); ?>">
+			<?php echo esc_html__('Dark', 'lottery-theme'); ?>
+		</button>
+	</div>
+</header>

--- a/wp-content/themes/lottery-theme/index.php
+++ b/wp-content/themes/lottery-theme/index.php
@@ -1,0 +1,27 @@
+<?php
+if (!defined('ABSPATH')) {
+	exit;
+}
+get_header();
+?>
+<main id="primary" class="site-main container">
+	<?php
+	if (have_posts()) {
+		while (have_posts()) {
+			the_post();
+			the_content();
+		}
+	} else {
+		echo '<p>' . esc_html__('No posts found.', 'lottery-theme') . '</p>';
+	}
+	?>
+
+	<?php
+	// Demo blocks (remove or keep as needed)
+	echo do_shortcode('[lottery_participants]');
+	echo do_shortcode('[wallet_balance]');
+	echo do_shortcode('[referral_link]');
+	?>
+</main>
+<?php
+get_footer();

--- a/wp-content/themes/lottery-theme/js/main.js
+++ b/wp-content/themes/lottery-theme/js/main.js
@@ -1,0 +1,100 @@
+(function () {
+	"use strict";
+
+	function getHtmlEl() {
+		return document.documentElement;
+	}
+
+	function getStoredTheme() {
+		try {
+			return localStorage.getItem("lottery-theme");
+		} catch (e) {
+			return null;
+		}
+	}
+
+	function storeTheme(mode) {
+		try {
+			localStorage.setItem("lottery-theme", mode);
+		} catch (e) {}
+	}
+
+	function applyTheme(mode) {
+		const html = getHtmlEl();
+		if (!html) return;
+		if (mode === "dark") {
+			html.setAttribute("data-theme", "dark");
+		} else {
+			html.removeAttribute("data-theme");
+		}
+		const btn = document.getElementById("lottery-dark-toggle");
+		if (btn) {
+			btn.textContent = mode === "dark"
+				? (window.lotteryTheme && lotteryTheme.darkOff) || "Light"
+				: (window.lotteryTheme && lotteryTheme.darkOn) || "Dark";
+		}
+	}
+
+	function initTheme() {
+		const stored = getStoredTheme();
+		const prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+		const mode = stored || (prefersDark ? "dark" : "light");
+		applyTheme(mode);
+	}
+
+	function toggleTheme() {
+		const html = getHtmlEl();
+		const isDark = html && html.getAttribute("data-theme") === "dark";
+		const next = isDark ? "light" : "dark";
+		applyTheme(next);
+		storeTheme(next);
+	}
+
+	function handleCopyButtons() {
+		const buttons = document.querySelectorAll(".lottery-referral__copy");
+		if (!buttons || !buttons.length) return;
+		buttons.forEach(function (btn) {
+			btn.addEventListener("click", function () {
+				const targetSel = btn.getAttribute("data-target");
+				if (!targetSel) return;
+				const input = document.querySelector(targetSel);
+				if (!input) return;
+				input.select();
+				input.setSelectionRange(0, 99999);
+				try {
+					const ok = document.execCommand("copy");
+					if (ok) {
+						const orig = btn.textContent;
+						btn.textContent = (window.lotteryTheme && lotteryTheme.copiedLabel) || "Copied!";
+						setTimeout(function () {
+							btn.textContent = orig || ((window.lotteryTheme && lotteryTheme.copyLabel) || "Copy");
+						}, 1200);
+					}
+				} catch (e) {}
+			});
+		});
+	}
+
+	document.addEventListener("DOMContentLoaded", function () {
+		initTheme();
+
+		var toggle = document.getElementById("lottery-dark-toggle");
+		if (toggle) {
+			toggle.addEventListener("click", toggleTheme);
+		}
+
+		handleCopyButtons();
+
+		if (window.matchMedia) {
+			try {
+				window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", function (e) {
+					const stored = getStoredTheme();
+					if (!stored) {
+						applyTheme(e.matches ? "dark" : "light");
+					}
+				});
+			} catch (e) {}
+		}
+	});
+})();
+

--- a/wp-content/themes/lottery-theme/style-rtl.css
+++ b/wp-content/themes/lottery-theme/style-rtl.css
@@ -1,0 +1,19 @@
+body {
+	direction: rtl;
+}
+
+.nav-primary a {
+	margin-left: 0;
+	margin-right: 0;
+}
+
+.lottery-referral__copy {
+	margin-inline-start: 0;
+	margin-inline-end: 8px;
+}
+
+.site-header__inner,
+.footer__inner,
+.container {
+	/* Logical props already help; ensure text aligns naturally */
+}

--- a/wp-content/themes/lottery-theme/style.css
+++ b/wp-content/themes/lottery-theme/style.css
@@ -1,0 +1,151 @@
+/*
+Theme Name: Lottery Theme
+Theme URI: https://example.com/lottery-theme
+Author: Your Name
+Author URI: https://example.com
+Description: Lottery theme with dark mode, participant counter, wallet balance, referral link, and RTL support.
+Version: 1.0.0
+Text Domain: lottery-theme
+Requires at least: 5.8
+Tested up to: 6.6
+Requires PHP: 7.4
+*/
+
+:root {
+	--bg: #ffffff;
+	--fg: #1f2937;
+	--muted: #6b7280;
+	--primary: #2563eb;
+	--surface: #f3f4f6;
+	--border: #e5e7eb;
+}
+
+html[data-theme="dark"] {
+	--bg: #0b1220;
+	--fg: #e5e7eb;
+	--muted: #9ca3af;
+	--primary: #60a5fa;
+	--surface: #111827;
+	--border: #1f2937;
+}
+
+html, body {
+	margin: 0;
+	padding: 0;
+	background: var(--bg);
+	color: var(--fg);
+	font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+	line-height: 1.6;
+}
+
+a {
+	color: var(--primary);
+	text-decoration: none;
+}
+a:hover, a:focus {
+	text-decoration: underline;
+}
+
+.site-header {
+	border-bottom: 1px solid var(--border);
+	background: var(--surface);
+}
+.site-header__inner {
+	max-width: 1100px;
+	margin: 0 auto;
+	padding: 12px 16px;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+}
+.site-title a {
+	color: var(--fg);
+	font-weight: 700;
+	font-size: 20px;
+}
+
+.nav-primary a {
+	padding: 6px 10px;
+	border-radius: 6px;
+}
+.nav-primary a:hover {
+	background: var(--border);
+	text-decoration: none;
+}
+
+.dark-toggle {
+	background: transparent;
+	border: 1px solid var(--border);
+	color: var(--fg);
+	padding: 6px 10px;
+	border-radius: 6px;
+	cursor: pointer;
+}
+.dark-toggle:focus {
+	outline: 2px solid var(--primary);
+	outline-offset: 2px;
+}
+
+.container {
+	max-width: 1100px;
+	margin: 0 auto;
+	padding: 20px 16px;
+}
+
+.footer {
+	border-top: 1px solid var(--border);
+	background: var(--surface);
+	color: var(--muted);
+}
+.footer__inner {
+	max-width: 1100px;
+	margin: 0 auto;
+	padding: 20px 16px;
+	font-size: 14px;
+}
+
+.lottery-participants {
+	display: grid;
+	gap: 8px;
+	margin: 16px 0;
+}
+.lottery-participants__count {
+	font-weight: 600;
+}
+.lottery-progress {
+	width: 100%;
+	height: 10px;
+	background: var(--border);
+	border-radius: 999px;
+	overflow: hidden;
+}
+.lottery-progress__bar {
+	height: 100%;
+	background: var(--primary);
+	width: 0%;
+	transition: width 200ms ease;
+}
+
+.lottery-wallet,
+.lottery-referral {
+	margin: 16px 0;
+}
+
+.lottery-referral__input {
+	width: min(100%, 520px);
+	padding: 8px 10px;
+	border: 1px solid var(--border);
+	border-radius: 6px;
+	background: transparent;
+	color: var(--fg);
+}
+.lottery-referral__copy {
+	margin-inline-start: 8px;
+	padding: 8px 10px;
+	border: 1px solid var(--border);
+	border-radius: 6px;
+	background: var(--surface);
+	color: var(--fg);
+	cursor: pointer;
+}


### PR DESCRIPTION
Add a new WordPress 'Lottery Theme' with dark mode, participant counter, wallet balance, referral link, and RTL support as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-1a64e400-3897-4b4f-a105-ed7445af2304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1a64e400-3897-4b4f-a105-ed7445af2304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

